### PR TITLE
Exclude symbolic links in DeviceSupport directories

### DIFF
--- a/Utils/DataStore.swift
+++ b/Utils/DataStore.swift
@@ -296,6 +296,9 @@ class AppData: ObservableObject {
       
       subDirectories = subDirectories.flatMap { parentPath in
         (try? fm.listDirectory(parentPath, onlyDirectory: false)) ?? []
+      }.filter { path in
+        let isSymbolicLink = try? fm.isSymbolicLink(path)
+        return !(isSymbolicLink ?? false)
       }
     }
     

--- a/Utils/FileHelper.swift
+++ b/Utils/FileHelper.swift
@@ -156,4 +156,11 @@ class FileHelper {
     let fileAttrs = try FileManager.default.attributesOfItem(atPath: path)
     return fileAttrs[FileAttributeKey.modificationDate] as! Date
   }
+  
+  func isSymbolicLink(_ path: String) throws -> Bool {
+    if let type = try? FileManager.default.attributesOfItem(atPath: path)[.type] as? FileAttributeType {
+      return type == .typeSymbolicLink
+    }
+    return false
+  }
 }


### PR DESCRIPTION
The device support directory may contain symbolic links, which should not be deleted:

The directory `10.16` below is a symbolic link and it shows up for XcodeCleaner.

<img width="863" alt="2022-09-12 14 15 15" src="https://user-images.githubusercontent.com/8158163/189585552-6c3e8079-8973-49ec-acb5-1ad426317e0b.png">

<img width="1032" alt="2022-09-12 14 08 53" src="https://user-images.githubusercontent.com/8158163/189585557-bb1daf4b-cf94-46c4-8a97-125dbf80ee66.png">

This PR adds extra checks to exclude symbolic links in DeviceSupport directories.
