### PR TITLE
Update openPanel’s default location

### DIFF
--- a/Utils/FileHelper.swift
+++ b/Utils/FileHelper.swift
@@ -53,7 +53,7 @@ class FileHelper {
     openPanel.canChooseDirectories = true
     openPanel.canCreateDirectories = false
     openPanel.canChooseFiles = false
-    //        openPanel.title = CHOOSE_DEVELOPER_DIR
+    openPanel.directoryURL = URL(fileURLWithPath: FileHelper.standard.getDefaultXcodePath())
     openPanel.message = "\(CHOOSE_DEVELOPER_DIR)\n\(CHOOSE_DEVELOPER_DIR_TIP)"
     openPanel.showsHiddenFiles = true
     openPanel.begin { (result) -> Void in


### PR DESCRIPTION
Update openPanel’s default location to “~/Library/Developer”

So that user could just click "open" to finish the permission grant process.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/43724855/197720806-b75fc17a-4b44-4924-a54a-99e2d5b417bc.png">


