### PR TITLE
Add copy command button to result view header

### DIFF
--- a/Cleaner4Xcode/MainWindowView.swift
+++ b/Cleaner4Xcode/MainWindowView.swift
@@ -71,7 +71,7 @@ struct ResultsTableView: View {
       analysis.objectWillChange.send()
       
       if let index = analysis.items.firstIndex(where: { $0.path == path }) {
-        // 重新计算 analysi 的总大小
+        // 重新计算 analysis 的总大小
         let item = analysis.items.remove(at: index)
         analysis.totalSize = analysis.items.reduce(0) {
           $0 + $1.totalSize
@@ -146,12 +146,22 @@ struct MainWindowView: View {
   
   var dataView: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack(alignment: .top) {
-        Text(LocalizedStringKey(
-          data.selectedGroup!.group.describe().summary))
+      let group = data.selectedGroup!.group.describe()
+      HStack(alignment: .center) {
+        Text(LocalizedStringKey(group.summary))
           .font(.footnote)
           .foregroundColor(.secondary)
-      
+        if let command = group.command {
+          Button {
+            let pasteboard = NSPasteboard.general
+            pasteboard.declareTypes([.string], owner: nil)
+            pasteboard.setString(command, forType: .string)
+          } label: {
+            Text("copy_command_title")
+              .font(.footnote)
+              .foregroundColor(.primary)
+          }
+        }
         Spacer()
       }
       .padding(.horizontal)

--- a/Cleaner4Xcode/en.lproj/Localizable.strings
+++ b/Cleaner4Xcode/en.lproj/Localizable.strings
@@ -13,7 +13,7 @@
 "analysis.previews.summary" = "SwiftUI Previews simulator and data. I suggest you run `xcrun simctl --set previews delete unavailable` to reduce the size safely.";
 "analysis.simulatorCaches.summary" = "Simulator runtime caches";
 
-
+"copy_command_title" = "Copy command";
 "sidebar.welcome" = "Welcome";
 "test_i18n" = "test I18N";
 "welcome.need_authorize" = "Need ~/Library/Developer permission to analyze and clean Xcode files.";

--- a/Cleaner4Xcode/pt-br.lproj/Localizable.strings
+++ b/Cleaner4Xcode/pt-br.lproj/Localizable.strings
@@ -13,7 +13,7 @@
 "analysis.previews.summary" = "Dados e SwiftUI simulator Previews";
 "analysis.simulatorCaches.summary" = "Simulator caches de runtime";
 
-
+"copy_command_title" = "Copiar comando";
 "sidebar.welcome" = "Bem Vindo";
 "test_i18n" = "test I18N";
 "welcome.need_authorize" = "É necessário acesso a pasta ~/Library/Developer para analisar e limpar arquivos Xcode.";

--- a/Cleaner4Xcode/th.lproj/Localizable.strings
+++ b/Cleaner4Xcode/th.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "analysis.derivedData.summary" = "โฟลเดอร์นี้สามารถลบทิ้ง ทั้งโฟลเดอร์ได้อย่างปลอดภัย คุณเพียงสั่ง rebuild โปรเจคของคุณอีกครั้ง ทุกอย่างก็จะกลับมาปรกติ";
 "analysis.previews.summary" = "SwiftUI Previews simulator and data";
 
+"copy_command_title" = "คัดลอกคำสั่ง";
 "sidebar.welcome" = "หน้าแรก";
 "test_i18n" = "test I18N";
 "welcome.need_authorize" = "ต้องการสิทธิ์ในการเข้าถึง ~/Library/Developer เพื่อวิเคราะห์และทำล้างข้อมูลของ Xcode ที่ไม่จำเป็น";

--- a/Cleaner4Xcode/zh-Hans.lproj/Localizable.strings
+++ b/Cleaner4Xcode/zh-Hans.lproj/Localizable.strings
@@ -11,6 +11,7 @@
 "welcome.button_analyze" = "开始分析";
 "welcome.button_analyze_again" = "再来一遍";
 "welcome.button_change_location" = "选择其它目录";
+"copy_command_title" = "复制命令";
 
 "analysis.iOSDeviceSupport.summary" = "iOS 真机调试文件，设备通过 USB 连接时会自动生成对应系统版本的调试信息，只需要保留您持有的设备当前的最新版本即可。";
 "analysis.watchOSDeviceSupport.summary" = "watchOS 真机调试文件，设备通过 USB 连接时会自动生成对应系统版本的调试信息，只需要保留您持有的设备当前的最新版本即可。";

--- a/Components/AnalysisView.swift
+++ b/Components/AnalysisView.swift
@@ -13,7 +13,7 @@ struct AnalysisView: View {
   @ObservedObject var analysis: Analysis
 
   var body: some View {
-    let (title, _) = analysis.group.describe()
+    let (title, _, _) = analysis.group.describe()
 
     return
       HStack {
@@ -23,7 +23,7 @@ struct AnalysisView: View {
             .foregroundColor(.primary)
 
           Text(humanize(analysis.totalSize))
-            .font(Font.headline.monospacedDigit())
+            .font(.headline.monospacedDigit())
             .bold()
             .foregroundColor(.pink)
 

--- a/Utils/DataStore.swift
+++ b/Utils/DataStore.swift
@@ -63,24 +63,24 @@ func humanize(_ fileSize: UInt64) -> String{
 enum AnalysisGroup: String {
   case archives, simulators, deviceSupport, iosDeviceSupport, watchOsDeviceSupport, derivedData, previews, coreSimulatorCaches;
   
-  func describe() -> (title: String, summary: String) {
+  func describe() -> (title: String, summary: String, command: String?) {
     switch self {
     case .deviceSupport:
-      return ("Device Support", "analysis.iOSDeviceSupport.summary")
+      return ("Device Support", "analysis.iOSDeviceSupport.summary", nil)
     case .archives:
-      return ("Archives", "analysis.archives.summary")
+      return ("Archives", "analysis.archives.summary", nil)
     case .simulators:
-      return ("Simulators", "analysis.simulators.summary")
+      return ("Simulators", "analysis.simulators.summary", "xcrun simctl delete unavailable")
     case .iosDeviceSupport:
-      return ("iOS DeviceSupport", "analysis.iOSDeviceSupport.summary")
+      return ("iOS DeviceSupport", "analysis.iOSDeviceSupport.summary", nil)
     case .derivedData:
-      return ("DerivedData", "analysis.derivedData.summary")
+      return ("DerivedData", "analysis.derivedData.summary", nil)
     case .watchOsDeviceSupport:
-      return ("watchOS DeviceSupport", "analysis.watchOSDeviceSupport.summary")
+      return ("watchOS DeviceSupport", "analysis.watchOSDeviceSupport.summary", nil)
     case .previews:
-      return ("SwiftUI Previews", "analysis.previews.summary")
+      return ("SwiftUI Previews", "analysis.previews.summary", "xcrun simctl --set previews delete unavailable")
     case .coreSimulatorCaches:
-      return ("Caches", "analysis.simulatorCaches.summary")
+      return ("Caches", "analysis.simulatorCaches.summary", nil)
     }
   }
 }


### PR DESCRIPTION
## Summary

* Add `copy command` button to the `Simulators` and `SwiftUI Previews` group.
* Clicking the button copies the command to `NSPasteboard.general`.
* Add localization for button titles.

## Preview

Simulators|SwiftUI Previews
:-:|:-:
<img width="1016" alt="Simulator" src="https://github.com/waylybaye/XcodeCleaner-SwiftUI/assets/11523500/709ba020-40d1-42da-9767-c3f3ba2b1683">|<img width="1016" alt="SwiftUIPreview" src="https://github.com/waylybaye/XcodeCleaner-SwiftUI/assets/11523500/7a3a477f-0f52-4522-ad8d-54d909a55270">